### PR TITLE
Use hasMoreElements with search limit instead of hasMore

### DIFF
--- a/src/main/java/cd/go/framework/ldap/Ldap.java
+++ b/src/main/java/cd/go/framework/ldap/Ldap.java
@@ -102,8 +102,8 @@ public class Ldap {
             NamingEnumeration<SearchResult> searchResults = null;
             try {
                 searchResults = context.search(base, filter, filterArgs, getSimpleSearchControls(maxResult));
-                while (searchResults.hasMore() && results.size() < maxResult) {
-                    results.add(searchResults.next());
+                while (searchResults.hasMoreElements() && results.size() < maxResult) {
+                    results.add(searchResults.nextElement());
                 }
                 if (results.size() >= maxResult) {
                     break;


### PR DESCRIPTION
If a search() method was invoked with a specified size limit of 'n'. If the answer consists of more than 'n' results, search() would first return a NamingEnumeration. When the n'th result has been returned by invoking next() on the NamingEnumeration,

* SizeLimitExceedException would then thrown when hasMore() is invoked.
* Invoking hasMoreElements() would return false.