### PR TITLE
explain two issues that tripped me up for hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Alternatively, the configuration can be added directly to the `config.xml` using
     </property>
     ```
 
+if you are trying to configure ldaps then use the url as:
+
+    ```xml
+    <property>
+       <key>Url</key>
+       <value>ldaps://ldap-server-url:1234</value>
+    </property>
+    ```
+
 * **ManagerDN (Optional):**  The LDAP/AD manager user's DN, used to connect to the LDAP/AD server.
  
     ```xml
@@ -170,8 +179,10 @@ Edit the file `wrapper-properties.conf` on your GoCD server and add the followin
 
 ```properties
 # We recommend that you begin with the index `100` and increment the index for each system property
-wrapper.java.additional.100=-Dplugin.cd.go.authentication.ldap.log.level=debug
+wrapper.java.additional.105=-Dplugin.cd.go.authentication.ldap.log.level=debug
 ```
+
+For this to work it's extremely important that there are no other entries with the same index number for `wrapper.java.additional`. E.g. with the docker version in the docker-entrypoint.sh is a line that adds an item for `wrapper.java.additional.100` but _only_ after boot time.
 
 If you're running with GoCD server 19.6 and above on docker using one of the supported GoCD server images, set the environment variable `GOCD_SERVER_JVM_OPTIONS`:
 


### PR DESCRIPTION
the need to pub ldaps://xxxx in the URL when you need an ldaps connection is not obvious for for admins who dont setup ldaps/starttls all day. What makes this worse is the deprecated (?) starttls setting in the cruise-config.xml that appears to do the same thing... hence i just assumed that i was requesting ldap over tls until i went and read some of the code...

The second change in the docs is regarding the debug. the line in the gocd server base docker image

```
GOCD_SERVER_JVM_OPTS+=("-Dgo.console.stdout=true")
```

which gets added into the wrapper-properties.conf _after_ boot time as: 

```
wrapper.java.additional.100=-Dgo.console.stdout=true
```

so obviously this conflicts with any other entries with index100 and caused debugging to not work until i discovered it..

