### PR TITLE
Partial migration to Apache DS 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,14 +100,15 @@ dependencies {
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
   testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher'
 
-  integrationTestImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
+  integrationTestImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.3'
   integrationTestImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.5'
   integrationTestImplementation project.deps.apacheDs
   integrationTestImplementation group: 'org.apache.directory.server', name: 'apacheds-core-annotations', version: project.versions.apacheDs
-  integrationTestImplementation group: 'org.apache.directory.server', name: 'apacheds-core-integ', version: '2.0.0-M24'
+  integrationTestImplementation group: 'org.apache.directory.server', name: 'apacheds-core-integ', version: project.versions.apacheDs
   integrationTestImplementation group: 'org.apache.directory.server', name: 'apacheds-core-jndi', version: project.versions.apacheDs
   integrationTestImplementation group: 'org.apache.directory.server', name: 'apacheds-core-constants', version: project.versions.apacheDs
-  integrationTestRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine'
+  integrationTestRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
+  integrationTestRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher'
 }
 
 test {

--- a/src/integration/cd/go/apacheds/LdapIntegrationTest.java
+++ b/src/integration/cd/go/apacheds/LdapIntegrationTest.java
@@ -24,9 +24,15 @@ import cd.go.authentication.ldap.mapper.UsernameResolver;
 import cd.go.authentication.ldap.model.LdapConfiguration;
 import cd.go.authentication.ldap.model.User;
 import org.apache.directory.ldap.client.template.exception.LdapRuntimeException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.util.List;
 
@@ -34,10 +40,21 @@ import static cd.go.authentication.ldap.PluginSystemProperty.USE_JNDI_LDAP_CLIEN
 import static java.text.MessageFormat.format;
 import static org.assertj.core.api.Assertions.*;
 
+@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
+@ExtendWith(SystemStubsExtension.class)
 public class LdapIntegrationTest extends BaseIntegrationTest {
-    @Rule
-    public final ProvideSystemProperty systemProperty = new ProvideSystemProperty(USE_JNDI_LDAP_CLIENT, "false");
+
+    @SystemStub
+    private SystemProperties systemProperties;
     private ApacheDsLdapClient ldap;
+
+    @BeforeEach
+    public void setUp() {
+        systemProperties.set(USE_JNDI_LDAP_CLIENT, "true");
+    }
 
     @Test
     public void authenticate_shouldAuthenticateUser() {

--- a/src/integration/cd/go/authentication/ldap/BaseIntegrationTest.java
+++ b/src/integration/cd/go/authentication/ldap/BaseIntegrationTest.java
@@ -18,21 +18,14 @@ package cd.go.authentication.ldap;
 
 import cd.go.authentication.ldap.model.LdapConfiguration;
 import com.google.gson.Gson;
-import org.apache.directory.server.annotations.CreateLdapServer;
-import org.apache.directory.server.annotations.CreateTransport;
-import org.apache.directory.server.core.annotations.ApplyLdifFiles;
 import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
-import org.apache.directory.server.core.integ.FrameworkRunner;
-import org.junit.runner.RunWith;
+import org.apache.directory.server.core.integ.ApacheDSTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(FrameworkRunner.class)
-@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
-@CreateLdapServer(transports = {
-        @CreateTransport(protocol = "LDAP")
-})
+@ExtendWith(ApacheDSTestExtension.class)
 public abstract class BaseIntegrationTest extends AbstractLdapTestUnit {
     protected LdapConfiguration ldapConfiguration(String[] searchBases) {
         Map<String, String> configuration = configAsMap("uid=admin,ou=system", "secret", "(uid={0})", searchBases
@@ -59,7 +52,7 @@ public abstract class BaseIntegrationTest extends AbstractLdapTestUnit {
 
     private Map<String, String> configAsMap(String managerDN, String password, String userLoginFilter, String[] searchBases) {
         Map<String, String> configuration = new HashMap<>();
-        configuration.put("Url", String.format("ldap://localhost:%s", ldapServer.getPort()));
+        configuration.put("Url", String.format("ldap://localhost:%s", classLdapServer.getPort()));
         configuration.put("SearchBases", String.join("\n", searchBases));
         configuration.put("ManagerDN", managerDN);
         configuration.put("Password", password);

--- a/src/integration/cd/go/authentication/ldap/LdapAuthenticatorIntegrationTest.java
+++ b/src/integration/cd/go/authentication/ldap/LdapAuthenticatorIntegrationTest.java
@@ -17,13 +17,20 @@
 package cd.go.authentication.ldap;
 
 import cd.go.authentication.ldap.model.*;
-import org.junit.Test;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
 public class LdapAuthenticatorIntegrationTest extends BaseIntegrationTest {
 
     @Test

--- a/src/integration/cd/go/authentication/ldap/LdapPluginIntegrationTest.java
+++ b/src/integration/cd/go/authentication/ldap/LdapPluginIntegrationTest.java
@@ -21,8 +21,11 @@ import com.google.gson.JsonObject;
 import com.thoughtworks.go.plugin.api.request.DefaultGoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static cd.go.authentication.ldap.executor.RequestFromServer.*;
 import static cd.go.plugin.base.ResourceReader.readResource;
@@ -32,10 +35,14 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
+@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
 public class LdapPluginIntegrationTest extends BaseIntegrationTest {
     private LdapPlugin ldapPlugin;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ldapPlugin = new LdapPlugin();
         ldapPlugin.initializeGoApplicationAccessor(null);

--- a/src/integration/cd/go/authentication/ldap/executor/IsValidUserExecutorIntegrationTest.java
+++ b/src/integration/cd/go/authentication/ldap/executor/IsValidUserExecutorIntegrationTest.java
@@ -22,8 +22,11 @@ import cd.go.authentication.ldap.model.AuthConfig;
 import cd.go.authentication.ldap.model.IsValidUserRequest;
 import cd.go.authentication.ldap.model.LdapConfiguration;
 import com.google.gson.Gson;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,10 +34,14 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
 public class IsValidUserExecutorIntegrationTest extends BaseIntegrationTest {
     private LdapFactory ldapFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ldapFactory = spy(new LdapFactory());
     }

--- a/src/integration/cd/go/authentication/ldap/executor/SearchUserExecutorIntegrationTest.java
+++ b/src/integration/cd/go/authentication/ldap/executor/SearchUserExecutorIntegrationTest.java
@@ -25,8 +25,11 @@ import cd.go.authentication.ldap.model.User;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
@@ -34,11 +37,15 @@ import static cd.go.authentication.ldap.utils.Util.GSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
 public class SearchUserExecutorIntegrationTest extends BaseIntegrationTest {
     private LdapFactory ldapFactory;
     private SearchUserExecutor searchUserExecutor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ldapFactory = spy(new LdapFactory());
         searchUserExecutor = new SearchUserExecutor(ldapFactory);

--- a/src/integration/cd/go/framework/ldap/LdapIntegrationTest.java
+++ b/src/integration/cd/go/framework/ldap/LdapIntegrationTest.java
@@ -22,9 +22,15 @@ import cd.go.authentication.ldap.mapper.UserMapper;
 import cd.go.authentication.ldap.mapper.UsernameResolver;
 import cd.go.authentication.ldap.model.LdapConfiguration;
 import cd.go.authentication.ldap.model.User;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import javax.naming.directory.DirContext;
 import java.util.List;
@@ -35,10 +41,21 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@ApplyLdifFiles(value = "users.ldif", clazz = BaseIntegrationTest.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
+@ExtendWith(SystemStubsExtension.class)
 public class LdapIntegrationTest extends BaseIntegrationTest {
-    @Rule
-    public final ProvideSystemProperty systemProperty = new ProvideSystemProperty(USE_JNDI_LDAP_CLIENT, "true");
+
+    @SystemStub
+    private SystemProperties systemProperties;
     private JNDILdapClient jndiLdapClient;
+
+    @BeforeEach
+    public void setUp() {
+        systemProperties.set(USE_JNDI_LDAP_CLIENT, "true");
+    }
 
     @Test
     public void authenticate_shouldAuthenticateUser() {


### PR DESCRIPTION
To make this work requires migration to the LDAP Client API v2 which is probably extra work. Earlier version of this which has some other bits addressed is at https://github.com/gocd/gocd-ldap-authentication-plugin/pull/171